### PR TITLE
fix: sync Cargo.toml version to 0.4.82

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bhumi"
-version = "0.1.0"
+version = "0.4.82"
 authors = ["Rach Pradhan <rach@rachpradhan.com>"]
 edition = "2021"
 description = "High performance LLM client with batching capabilities and multi-provider support"


### PR DESCRIPTION
Sync Cargo.toml version with pyproject.toml so release workflow can bump to 0.5.0